### PR TITLE
Keep Live Activity alive during phone sleep

### DIFF
--- a/bowtie2/views/GameView.swift
+++ b/bowtie2/views/GameView.swift
@@ -29,7 +29,6 @@ fileprivate class GameViewSheetState: Identifiable {
 
 struct GameView: View {
     @Environment(\.managedObjectContext) private var viewContext
-    @Environment(\.scenePhase) private var scenePhase
     @EnvironmentObject var settings: UserSettings
 
     @ObservedObject var game: Game
@@ -88,21 +87,6 @@ struct GameView: View {
         }
         .onChange(of: game.keepScreenAwake) { newValue in
             UIApplication.shared.isIdleTimerDisabled = newValue
-        }
-        .onChange(of: scenePhase) { newPhase in
-            if #available(iOS 26, *) {
-                guard settings.liveActivitiesEnabled && game.liveActivityEnabled else { return }
-                Task {
-                    switch newPhase {
-                    case .background:
-                        await LiveActivityManager.shared.endWithDelayedDismissal(game: game)
-                    case .active:
-                        try? await LiveActivityManager.shared.start(game: game)
-                    default:
-                        break
-                    }
-                }
-            }
         }
     }
     


### PR DESCRIPTION
Live Activities should persist when the phone locks, not end immediately. The scenePhase handler was ending activities on background, which contradicts ActivityKit design where activities persist independently of app lifecycle. After 30 minutes of no score updates, the staleDate mechanism causes iOS to mark the activity as stale. This fixes the issue where activities disappeared too early.